### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/pkg/cmds/debug/gateway/config_dump.go
+++ b/pkg/cmds/debug/gateway/config_dump.go
@@ -78,7 +78,8 @@ func (g *gatewayOpts) forwardToPort(podMeta metav1.ObjectMeta, resource string, 
 			Namespace: podMeta.Namespace,
 			Name:      podMeta.Name,
 			Remote:    *port,
-		})
+		},
+	)
 	if err := tunnel.ForwardPort(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
